### PR TITLE
remove registry-url from Brightspace/setup-node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,6 @@ jobs:
         uses: Brightspace/setup-node@main
         with:
             node-version: '14.x'
-            registry-url: ${{ secrets.ARTIFACTORY_NPM_REGISTRY }}
-            scope: '@d2l'
       - name: Install Node Modules
         run: npm ci
       - name: Run lint


### PR DESCRIPTION
The `registry-url` input will soon be managed by Brightspace/setup-node itself.
The current usage isn't necessary.

[HOD-4561 - Proxy Registry > Update Brightspace/setup-node](https://desire2learn.atlassian.net/browse/HOD-4561)